### PR TITLE
[pypi] fixed license classifier and added long_description_content_type.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,7 @@ license = Apache
 license_file = LICENSE
 classifiers =
     Intended Audience :: Developers
-    License :: OSI Approved :: Apache Version 2
+    License :: OSI Approved :: Apache Software License
     Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3.6

--- a/setup.py
+++ b/setup.py
@@ -18,5 +18,6 @@ setup(name=name,
       license='Apache 2.0',
       description='Cloudstate Python Support Library',
       packages=find_packages(exclude=['tests', 'shoppingcart']),
-      long_description=open('README.md').read(),
+      long_description=open('README.md', 'r').read(),
+      long_description_content_type='text/markdown',
       zip_safe=False)


### PR DESCRIPTION
I published 0.1.0 today on pypi: https://pypi.org/project/cloudstate/0.1.0/

I had to made these two changes before pypi allowed it to be published. Tested it against a new python project and used the cloudstate python lib as a dependency. 
@sleipnir now we can start using the shopping cart as discussed.