### PR TITLE
Add setup for building and publishing docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .idea
 .vscode
 **/__pycache__/
+/docs/project/project/
+/docs/project/target/
+/docs/target/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,35 @@
 language: python
+
 python:
   - "3.8"
-install:
-  - pip install -r requirements.txt
-script: pytest
-deploy:
-  provider: pypi
-  username: "__token__"
-  password:
-    secure: "wHyj8a0t6Ub4BmJYSwDQO5wJphX3Wz55bDAlWrb4KaJGD4XzjFs5VWDqgZRAJ6JSM8WF9xQqVPxniXRpyBO41VDNGkyT5ytf0yohnw6kud/xwm8+y5BbJ1ZxmGmpxoJumc1R/tJNABlabLEvSr10OtuMnR7kW5d4WCBR/baugr8sCEXnNLDdxNOnCZhC36cm+yWRIi8ih8eUhkbJRLb/KQO1PDrHEf7V35PwLktSkhWkjr0mtSvbthPPn6hmH2PV+OnMD102oYbDO2eGWr8nhHAPcfXaDQgdBy9WQ20SgZqNmZc6LIwNV6MWdCV/BSk4sLithT/r5aZcL99fzxy+PFmJdbxJibPEqJyf8DVSQa9Pa2ndjNXnHJuqeEh4Xdcp90z1aRGEr988P/llFFnq8pDXCapAvdGeALh3IdANhTYJcQtZfcJ0D/aAnq0le8X5i4X39aPazbR4VPXDoDiFCPqxy5MJ2Y3skqX9dyXsKuqUMlfpfUsEnhW5RbnSCA53BYw9FoykLA9tvFtjnxywwHo1iFfDdhXU0z7L/bE5dlafct1WST6cnDHaqew8ew03OE3Z2DTBiV/aNDON2JvqgnqT4JW3T3xDUYR7pKbzEnVGq8oGS9nmxLU4ciXad7dRtrwb92Wv2Jbs4wkeLFCmoDhshtT7KEDANTxBS4tAk50="
-  on:
-    tags: true  
+
+jobs:
+  include:
+
+  - stage: build
+    install:
+      - pip install -r requirements.txt
+    script: pytest
+    deploy:
+      provider: pypi
+      username: "__token__"
+      password:
+        secure: "wHyj8a0t6Ub4BmJYSwDQO5wJphX3Wz55bDAlWrb4KaJGD4XzjFs5VWDqgZRAJ6JSM8WF9xQqVPxniXRpyBO41VDNGkyT5ytf0yohnw6kud/xwm8+y5BbJ1ZxmGmpxoJumc1R/tJNABlabLEvSr10OtuMnR7kW5d4WCBR/baugr8sCEXnNLDdxNOnCZhC36cm+yWRIi8ih8eUhkbJRLb/KQO1PDrHEf7V35PwLktSkhWkjr0mtSvbthPPn6hmH2PV+OnMD102oYbDO2eGWr8nhHAPcfXaDQgdBy9WQ20SgZqNmZc6LIwNV6MWdCV/BSk4sLithT/r5aZcL99fzxy+PFmJdbxJibPEqJyf8DVSQa9Pa2ndjNXnHJuqeEh4Xdcp90z1aRGEr988P/llFFnq8pDXCapAvdGeALh3IdANhTYJcQtZfcJ0D/aAnq0le8X5i4X39aPazbR4VPXDoDiFCPqxy5MJ2Y3skqX9dyXsKuqUMlfpfUsEnhW5RbnSCA53BYw9FoykLA9tvFtjnxywwHo1iFfDdhXU0z7L/bE5dlafct1WST6cnDHaqew8ew03OE3Z2DTBiV/aNDON2JvqgnqT4JW3T3xDUYR7pKbzEnVGq8oGS9nmxLU4ciXad7dRtrwb92Wv2Jbs4wkeLFCmoDhshtT7KEDANTxBS4tAk50="
+      on:
+        tags: true
+
+  - stage: deploy docs
+    name: deploy release docs to cloudstate.io
+    if: tag =~ ^v
+    language: scala
+    script: cd docs && sbt deploy
+  - stage: deploy docs
+    name: deploy snapshot docs to cloudstate.io
+    if: branch = master AND type = push
+    language: scala
+    script: cd docs && sbt deploy
+
+env:
+  global:
+    # encrypted with: travis encrypt --pro -r cloudstateio/python-support DEPLOY_DOCS_TOKEN=<token>
+    secure: "lALDa5xUg8uUAoxmn1XxwycRa+xp1IcohMuk+1i+GKI7BX60SI8ueHo+FZU3H+PF53CjtxA1UefsAFwz8smtWiePWbqalbLVMx7N2bt7tLjA/lhQC2+vEZu3LPMYGkxE/XwQ5Zr9KLgoci33USu3R6mxBgg3EbcVSSkOyBhGgH2VMIxktPf5Ae64khlhKJtkBlPgktuKytR6bESFMtdQ2v+wXQm0gQgTq85OhMc0hyixSO3JIshfEXd9Ywkfjj7j1njba/yb19tVeKh9GZh+PFLFp84CJwPE2R0ZoWGYMACsRwUQNmLaFb9y+GjTryanYlzbz8FGOVeL3INw7cDJriLopSYGEssiNGSZQh2U8+01N79VohzzBR+XSx/uw8Gly7C51rI7wFs0VbkUtPGFSbAcDGK6OqQ2fFsL1qwYIU+uLWpt2dtcxtbRsDpE3GL//8jUGLE6r6ov0b0W262PNbrmCaFdm9JzhjaypjvjMNBebmi4ezm8RS22lRT5wykJOzuifBTubgsSx7K2TIuTQrGv7zTOjnWoaSUy8nLiAuFp/WmCRQEaAZ9LXzLigzrnI+LtwPDnwvNP5xF+jmRnGxk27pFipDKmZZW/IXFR0uij14U7ewIFAWWtl/g2Fyi47JMXMLwR1IdBJ3QBZBlP+EX4SUvwg8YR1qUGRQbxXDs="

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,23 @@
+# Cloudstate Python documentation
+
+Documentation source for Cloudstate Python, published to https://cloudstate.io/docs/python/current/
+
+To build the docs with [sbt](https://www.scala-sbt.org):
+
+```
+sbt paradox
+```
+
+Can also first start the sbt interactive shell with `sbt`, then run commands.
+
+The documentation can be viewed locally by opening the generated pages:
+
+```
+open target/paradox/site/main/index.html
+```
+
+To watch files for changes and rebuild docs automatically:
+
+```
+sbt ~paradox
+```

--- a/docs/build.sbt
+++ b/docs/build.sbt
@@ -1,0 +1,10 @@
+lazy val docs = project
+  .in(file("."))
+  .enablePlugins(CloudstateParadoxPlugin)
+  .settings(
+    deployModule := "python",
+    paradoxProperties in Compile ++= Map(
+      "cloudstate.python.version" -> { if (isSnapshot.value) previousStableVersion.value.getOrElse("0.0.0") else version.value },
+      "extref.cloudstate.base_url" -> "https://cloudstate.io/docs/core/current/%s"
+    )
+  )

--- a/docs/project/build.properties
+++ b/docs/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.3.12

--- a/docs/project/plugins.sbt
+++ b/docs/project/plugins.sbt
@@ -1,0 +1,2 @@
+addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.0.0")
+addSbtPlugin("io.cloudstate" % "sbt-cloudstate-paradox" % "0.1.2")

--- a/docs/src/main/paradox/gettingstarted.md
+++ b/docs/src/main/paradox/gettingstarted.md
@@ -1,0 +1,11 @@
+# Getting started
+
+Install current version:
+
+@@@vars
+```
+pip install cloudstate==$cloudstate.python.version$
+```
+@@@
+
+Link to @extref:[event sourcing](cloudstate:user/features/eventsourced.html)

--- a/docs/src/main/paradox/index.md
+++ b/docs/src/main/paradox/index.md
@@ -1,0 +1,7 @@
+# Cloudstate Python
+
+Link to @extref:[core docs](cloudstate:index.html)
+
+@@@ index
+* [Getting started](gettingstarted.md)
+@@@


### PR DESCRIPTION
Since there are no docs yet, I thought the python support could be a good place to start with separate module docs for https://github.com/cloudstateio/cloudstate/issues/104.

This adds an sbt project for building and publishing docs, which uses the same setup and theme as for the main cloudstate documentation.

The docs are basically empty — just showing the properties for version (automatically based on git tags) and an extref created for cloudstate core docs.

This is set up for publishing docs automatically from travis — updated for multi-language build (which should work, let's confirm). The snapshot version should be published automatically once this PR is merged (and the PR should check the regular tests are still configured correctly).

Docs will be published to https://cloudstate.io/docs/python/current/ (and `/{version}`) on releases, and to https://cloudstate.io/docs/python/snapshot/ on doc changes to master.

Once actual docs are added, we can retro-publish for the current version (0.1.0), and we can add to the doc home page here: https://cloudstate.io/docs/